### PR TITLE
Fix scroll Bar is not accurately reflecting the virtual viewport position.

### DIFF
--- a/GDViews.VirtualGridView/Core/VirtualGridViewImpl.cs
+++ b/GDViews.VirtualGridView/Core/VirtualGridViewImpl.cs
@@ -42,7 +42,6 @@ internal class VirtualGridViewImpl<TDataType, TButtonType, TExtraArgument> :
 
     private NullableData<TDataType> _currentSelectedData;
     private int _currentSelectedViewColumnIndex;
-
     private int _currentSelectedViewRowIndex;
 
     private DataView[,] _currentView;
@@ -797,9 +796,10 @@ internal class VirtualGridViewImpl<TDataType, TButtonType, TExtraArgument> :
         }
         else
         {
-            rowProgress = ViewRowIndex / (float)(dataRows - ViewRows);
+            var fixedDataRows = (float)dataRows;
+            rowProgress = ViewRowIndex / fixedDataRows;
             rowProgress = Math.Max(rowProgress, 0f);
-            rowPage = ViewRows / (float)dataRows;
+            rowPage = ViewRows / fixedDataRows;
             canAutoHideRowScrollBar = false;
         }
 
@@ -811,9 +811,10 @@ internal class VirtualGridViewImpl<TDataType, TButtonType, TExtraArgument> :
         }
         else
         {
-            columnProgress = ViewColumnIndex / (float)(dataColumns - ViewColumns);
+            var fixedDataColumns = (float)dataColumns;
+            columnProgress = ViewColumnIndex / fixedDataColumns;
             columnProgress = Math.Max(columnProgress, 0f);
-            columnPage = ViewColumns / (float)dataColumns;
+            columnPage = ViewColumns / fixedDataColumns;
             canAutoHideColumnScrollBar = false;
         }
 


### PR DESCRIPTION
This fixes the issue (restoring the scroll bar to its correct designed behavior), however, I'm wondering if we need positioner-specific calculation, since the centered positioner can go beyond the viewport range.